### PR TITLE
feat(hooks): add pre-push hook to block direct pushes to main

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pre-push hook: mainブランチへの直接pushをブロック
+# Claude Code の PreToolUse(Bash) フックとして使用
+
+# stdin から tool_input を読み取る
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# git push コマンドかチェック
+if [[ "$COMMAND" != *"git push"* ]]; then
+  exit 0
+fi
+
+# 現在のブランチを取得
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# mainブランチへのpushをブロック
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+  echo "BLOCKED: mainへの直接pushはブロックされています。featureブランチからPRを作成してください。"
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -12,6 +12,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/your/project/.claude/hooks/block-main-push.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit|Bash",
         "hooks": [
           {

--- a/setup.sh
+++ b/setup.sh
@@ -128,6 +128,34 @@ if [ -d "$TEMPLATE/agents" ] && [ "$(ls -A "$TEMPLATE/agents" 2>/dev/null)" ]; t
   done
 fi
 
+# 共有フックをリンク
+echo ""
+echo "📁 Linking hooks..."
+SHARED_HOOKS=(block-main-push.sh)
+for hook in "${SHARED_HOOKS[@]}"; do
+  src="$TEMPLATE/hooks/$hook"
+  dst="$TARGET/hooks/$hook"
+  if [ -f "$src" ]; then
+    rm -f "$dst"
+    ln -s "$src" "$dst"
+    echo "   ✓ $hook"
+  else
+    echo "   ⚠ $hook (not in template)"
+  fi
+done
+
+# settings.json の PreToolUse フック登録確認
+SETTINGS_FILE="$TARGET/settings.json"
+if [ -f "$SETTINGS_FILE" ]; then
+  # block-main-push.sh が未登録なら案内
+  if ! grep -q "block-main-push.sh" "$SETTINGS_FILE" 2>/dev/null; then
+    echo ""
+    echo "   ⚠ block-main-push.sh is not registered in settings.json"
+    echo "   Add the following to PreToolUse hooks in $SETTINGS_FILE:"
+    echo '   {"matcher":"Bash","hooks":[{"type":"command","command":"<path>/hooks/block-main-push.sh"}]}'
+  fi
+fi
+
 # MCPs の案内
 TEMPLATE_ROOT="${TEMPLATE%/.claude}"
 echo ""


### PR DESCRIPTION
## Summary
- `block-main-push.sh` フックを追加: mainブランチへの直接pushをPreToolUseでブロック
- `setup.sh` にhooks配布セクションを追加: 全プロジェクトにsymlinkで配布
- `settings.local.json.example` にPreToolUseエントリを追加: 設定テンプレート

## Test plan
- [ ] block-main-push.sh がmainブランチでのgit pushをexit 2で拒否することを確認
- [ ] setup.sh実行時にhooks/block-main-push.shがsymlinkされることを確認
- [ ] featureブランチからのpushはブロックされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch protection that blocks accidental pushes to main and master branches
  * Automatic setup and configuration of protection hooks during project initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->