### PR TITLE
fix: setup.sh全スキル対応 & block-main-push.sh誤検出修正

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -16,8 +16,24 @@ if [[ "$COMMAND" == *"--delete"* ]]; then
   exit 0
 fi
 
-# 現在のブランチを取得
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+# コマンド内に git -C <path> がある場合、そのリポのブランチを取得
+# git -C /path/to/repo push ... のパターンを検出
+GIT_DIR_FLAG=""
+if [[ "$COMMAND" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  GIT_DIR_FLAG="${BASH_REMATCH[1]}"
+fi
+
+# cd <path> && git push ... のパターンを検出
+if [[ -z "$GIT_DIR_FLAG" && "$COMMAND" =~ cd[[:space:]]+([^[:space:];&]+).*git[[:space:]]+push ]]; then
+  GIT_DIR_FLAG="${BASH_REMATCH[1]}"
+fi
+
+# 対象リポのブランチを取得
+if [[ -n "$GIT_DIR_FLAG" ]]; then
+  CURRENT_BRANCH=$(git -C "$GIT_DIR_FLAG" rev-parse --abbrev-ref HEAD 2>/dev/null)
+else
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+fi
 
 # mainブランチへのpushをブロック
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,7 @@ mkdir -p "$TARGET"/{commands,skills,agents,hooks}
 
 # 共有コマンドをリンク
 echo "📁 Linking commands..."
-SHARED_COMMANDS=(commit pr build-fix security ship learn)
+SHARED_COMMANDS=(commit pr build-fix security ship learn codex ios)
 for cmd in "${SHARED_COMMANDS[@]}"; do
   src="$TEMPLATE/commands/$cmd.md"
   dst="$TARGET/commands/$cmd.md"
@@ -73,17 +73,44 @@ done
 echo ""
 echo "📁 Linking skills..."
 SHARED_SKILLS=(
+  # Development
   tdd
   coding-rules
   backend-patterns
-  ui-ux-pro-max
-  mcp
-  hooks
   git-worktree
+  hooks
+  mcp
+  remotion
+  ios-app-store-submission
+  vercel-react-best-practices
+  vercel-react-native-skills
+  vercel-composition-patterns
+  # Marketing & CRO
   lp-optimizer
-  ux-psychology
+  copywriting
+  seo-audit
   marketing-audit
+  marketing-psychology
+  launch-strategy
   pricing-strategy
+  ab-test-setup
+  analytics-tracking
+  core-web-vitals
+  email-sequence
+  referral-program
+  signup-flow-cro
+  onboarding-cro
+  form-cro
+  # UX & Product
+  ui-ux-pro-max
+  ux-psychology
+  web-design-guidelines
+  app-onboarding
+  paywall-upgrade-cro
+  # Content & Monetization
+  ai-interview-article
+  note-serial-monetization
+  freee-api-skill
 )
 for skill in "${SHARED_SKILLS[@]}"; do
   src="$TEMPLATE/skills/$skill"


### PR DESCRIPTION
## Summary
- setup.shのSHARED_SKILLS配列を11→34（全スキル）に拡張し、長期放置のTODOを消化
- block-main-push.shが別リポへのpushで誤検出する既知バグを修正

## Changes

### setup.sh
- SHARED_SKILLS: 11個 → 34個（全スキル）。カテゴリコメント付き
- SHARED_COMMANDS: 6個 → 8個（codex, ios追加）

### block-main-push.sh
- `git -C <path> push` パターンの検出を追加
- `cd <path> && git push` パターンの検出を追加
- 対象リポのブランチを正しく取得するようになり、CWDが別リポでも誤検出しない

## Test plan
- [ ] setup.shを新規プロジェクトで実行し、34スキルがリンクされることを確認
- [ ] featureブランチで `git push` が許可されることを確認
- [ ] mainブランチで `git push` がブロックされることを確認
- [ ] `git -C /other/repo push` で対象リポのブランチが正しく判定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codex` and `ios` commands to the platform
  * Expanded available skills including marketing, analytics, design, app development, CRO, and monetization capabilities

* **Chores**
  * Improved branch detection for git operations
  * Updated internal command and skill configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->