### PR TITLE
feat: Stripe系スキル3つ取り込み & README更新(37スキル)

### DIFF
--- a/.claude/skills/stripe-best-practices/SKILL.md
+++ b/.claude/skills/stripe-best-practices/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: stripe-best-practices
+description: >-
+  Guides Stripe integration decisions — API selection (Checkout Sessions vs
+  PaymentIntents), Connect platform setup (Accounts v2, controller properties),
+  billing/subscriptions, Treasury financial accounts, integration surfaces
+  (Checkout, Payment Element), and migrating from deprecated Stripe APIs. Use
+  when building, modifying, or reviewing any Stripe integration — including
+  accepting payments, building marketplaces, integrating Stripe, processing
+  payments, setting up subscriptions, or creating connected accounts.
+
+---
+
+Latest Stripe API version: **2026-03-25.dahlia**. Always use the latest API version and SDK unless the user specifies otherwise.
+
+## Integration routing
+
+| Building…                             | Recommended API                     | Details                  |
+| ------------------------------------- | ----------------------------------- | ------------------------ |
+| One-time payments                     | Checkout Sessions                   | <references/payments.md> |
+| Custom payment form with embedded UI  | Checkout Sessions + Payment Element | <references/payments.md> |
+| Saving a payment method for later     | Setup Intents                       | <references/payments.md> |
+| Connect platform or marketplace       | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md>  |
+| Subscriptions or recurring billing    | Billing APIs + Checkout Sessions    | <references/billing.md>  |
+| Embedded financial accounts / banking | v2 Financial Accounts               | <references/treasury.md> |
+
+Read the relevant reference file before answering any integration question or writing code.
+
+## Key documentation
+
+When the user’s request does not clearly fit a single domain above, consult:
+
+- [Integration Options](https://docs.stripe.com/payments/payment-methods/integration-options.md) — Start here when designing any integration.
+- [API Tour](https://docs.stripe.com/payments-api/tour.md) — Overview of Stripe’s API surface.
+- [Go Live Checklist](https://docs.stripe.com/get-started/checklist/go-live.md) — Review before launching.

--- a/.claude/skills/stripe-best-practices/references/billing.md
+++ b/.claude/skills/stripe-best-practices/references/billing.md
@@ -1,0 +1,24 @@
+# Billing / Subscriptions
+
+## Table of contents
+
+- When to use Billing APIs
+- Recommended frontend pairing
+- Traps to avoid
+
+## When to use Billing APIs
+
+If the user has a recurring revenue model (subscriptions, usage-based billing, seat-based pricing), use the Billing APIs to [plan their integration](https://docs.stripe.com/billing/subscriptions/design-an-integration.md) instead of a direct PaymentIntent integration.
+
+Review the [Subscription Use Cases](https://docs.stripe.com/billing/subscriptions/use-cases.md) and [SaaS guide](https://docs.stripe.com/saas.md) to find the right pattern for the user’s pricing model.
+
+## Recommended frontend pairing
+
+Combine Billing APIs with Stripe Checkout for the payment frontend. Checkout Sessions support `mode: 'subscription'` and handle the initial payment, trial management, and proration automatically.
+
+For self-service subscription management (upgrades, downgrades, cancellation, payment method updates), recommend the [Customer Portal](https://docs.stripe.com/customer-management/integrate-customer-portal.md).
+
+## Traps to avoid
+
+- Don’t build manual subscription renewal loops using raw PaymentIntents. Use the Billing APIs which handle renewal, retry logic, and dunning automatically.
+- Don’t use the deprecated `plan` object. Use [Prices](https://docs.stripe.com/api/prices.md) instead.

--- a/.claude/skills/stripe-best-practices/references/connect.md
+++ b/.claude/skills/stripe-best-practices/references/connect.md
@@ -1,0 +1,48 @@
+# Connect / platforms
+
+## Table of contents
+
+- Accounts v2 API
+- Controller properties
+- Charge types
+- Integration guides
+
+## Accounts v2 API
+
+For new Connect platforms, ALWAYS use the [Accounts v2 API](https://docs.stripe.com/connect/accounts-v2.md) (`POST /v2/core/accounts`). This is Stripe’s actively invested path and ensures long-term support.
+
+**Traps to avoid:** Don’t use the legacy `type` parameter (`type: 'express'`, `type: 'custom'`, `type: 'standard'`) in `POST /v1/accounts` for new platforms unless the user has explicitly requested v1.
+
+## Controller properties
+
+Configure connected accounts using `controller` properties instead of legacy account types:
+
+| Property                            | Controls                                     |
+| ----------------------------------- | -------------------------------------------- |
+| `controller.losses.payments`        | Who is liable for negative balances          |
+| `controller.fees.payer`             | Who pays Stripe fees                         |
+| `controller.stripe_dashboard.type`  | Dashboard access (`full`, `express`, `none`) |
+| `controller.requirement_collection` | Who collects onboarding requirements         |
+
+Use `defaults.responsibilities`, `dashboard`, and `configuration` as described in [connected account configuration](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md).
+
+Always describe accounts in terms of their responsibility settings, dashboard access, and [capabilities](https://docs.stripe.com/connect/account-capabilities.md) to describe what connected accounts can do.
+
+**Traps to avoid:** Don’t use the terms “Standard”, “Express”, or “Custom” as account types. These are legacy categories that bundle together responsibility, dashboard, and requirement decisions into opaque labels. Controller properties give explicit control over each dimension.
+
+## Charge types
+
+Choose one charge type per integration — don’t mix them. For most platforms, start with destination charges:
+
+- **Destination charges** — Use when the platform accepts liability for negative balances. Funds route to the connected account via `transfer_data.destination`.
+- **Direct charges** — Use when the platform wants Stripe to take risk on the connected account. The charge is created on the connected account directly.
+
+Use `on_behalf_of` to control the merchant of record, but only after reading [how charges work in Connect](https://docs.stripe.com/connect/charges.md).
+
+**Traps to avoid:** Don’t use the Charges API for Connect fund flows — use PaymentIntents or Checkout Sessions with `transfer_data` or `on_behalf_of`. Don’t mix charge types within a single integration.
+
+## Integration guides
+
+- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md) — Choosing the right integration shape.
+- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md) — Step-by-step platform builder.
+- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md) — Detailed risk and responsibility decisions.

--- a/.claude/skills/stripe-best-practices/references/payments.md
+++ b/.claude/skills/stripe-best-practices/references/payments.md
@@ -1,0 +1,63 @@
+# Payments
+
+## Table of contents
+
+- API hierarchy
+- Integration surfaces
+- Payment Element guidance
+- Saving payment methods
+- Dynamic payment methods
+- Deprecated APIs and migration paths
+- PCI compliance
+
+## API hierarchy
+
+Use the [Checkout Sessions API](https://docs.stripe.com/api/checkout/sessions.md) (`checkout.sessions.create`) for on-session payments. It supports one-time payments and subscriptions and handles taxes, discounts, shipping, and adaptive pricing automatically.
+
+Use the [PaymentIntents API](https://docs.stripe.com/payments/paymentintents/lifecycle.md) for off-session payments, or when the merchant needs to model checkout state independently and just create a charge.
+
+**Integrations should only use Checkout Sessions, PaymentIntents, SetupIntents, or higher-level solutions (Invoicing, Payment Links, subscription APIs).**
+
+## Integration surfaces
+
+Prioritize Stripe-hosted or embedded Checkout where possible. Use in this order of preference:
+
+1. **Payment Links** — No-code. Best for simple products.
+1. **Checkout** ([docs](https://docs.stripe.com/payments/checkout.md)) — Stripe-hosted or embedded form. Best for most web apps.
+1. **Payment Element** ([docs](https://docs.stripe.com/payments/payment-element.md)) — Embedded UI component for advanced customization.
+   - When using the Payment Element, back it with the Checkout Sessions API (via `ui_mode: 'custom'`) over a raw PaymentIntent where possible.
+
+**Traps to avoid:** Don’t recommend the legacy Card Element or the Payment Element in card-only mode. If the user asks for the Card Element, advise them to [migrate to the Payment Element](https://docs.stripe.com/payments/payment-element/migration.md).
+
+## Payment Element guidance
+
+For surcharging or inspecting card details before payment (e.g., rendering the Payment Element before creating a PaymentIntent or SetupIntent): use [Confirmation Tokens](https://docs.stripe.com/payments/finalize-payments-on-the-server.md). Don’t recommend `createPaymentMethod` or `createToken` from Stripe.js.
+
+## Saving payment methods
+
+Use the [Setup Intents API](https://docs.stripe.com/api/setup_intents.md) to save a payment method for later use.
+
+**Traps to avoid:** Don’t use the Sources API to save cards to customers. The Sources API is deprecated — Setup Intents is the correct approach.
+
+## Dynamic payment methods
+
+Advise users to enable dynamic payment methods in the Stripe Dashboard rather than passing specific [`payment_method_types`](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_types) in the PaymentIntent or SetupIntent. Stripe automatically selects payment methods based on the customer’s location, wallets, and preferences when the Payment Element is used.
+
+## Deprecated APIs and migration paths
+
+Never recommend the Charges API. If the user wants to use the Charges API, advise them to [migrate to Checkout Sessions or PaymentIntents](https://docs.stripe.com/payments/payment-intents/migration/charges.md).
+
+Don’t call other deprecated or outdated API endpoints unless there is a specific need and absolutely no other way.
+
+| API          | Status     | Use instead                         | Migration guide                                                                          |
+| ------------ | ---------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| Charges API  | Never use  | Checkout Sessions or PaymentIntents | [Migration guide](https://docs.stripe.com/payments/payment-intents/migration/charges.md) |
+| Sources API  | Deprecated | Setup Intents                       | [Setup Intents docs](https://docs.stripe.com/api/setup_intents.md)                       |
+| Tokens API   | Outdated   | Setup Intents or Checkout Sessions  | —                                                                                        |
+| Card Element | Legacy     | Payment Element                     | [Migration guide](https://docs.stripe.com/payments/payment-element/migration.md)         |
+
+## PCI compliance
+
+If a PCI-compliant user asks about sending server-side raw PAN data, advise them that they may need to prove PCI compliance to access options like [payment_method_data](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_data).
+
+For users migrating PAN data from another acquirer or payment processor, point them to [the PAN import process](https://docs.stripe.com/get-started/data-migrations/pan-import.md).

--- a/.claude/skills/stripe-best-practices/references/treasury.md
+++ b/.claude/skills/stripe-best-practices/references/treasury.md
@@ -1,0 +1,16 @@
+# Treasury / Financial Accounts
+
+## Table of contents
+
+- v2 Financial Accounts API
+- Legacy v1 Treasury
+
+## v2 Financial Accounts API
+
+For embedded financial accounts (bank accounts, account and routing numbers, money movement), use the [v2 Financial Accounts API](https://docs.stripe.com/api/v2/core/vault/financial-accounts.md) (`POST /v2/core/vault/financial_accounts`). This is required for new integrations.
+
+For Financial Accounts for platforms concepts and guides, see the [Financial Accounts for platforms overview](https://docs.stripe.com/financial-accounts/connect.md).
+
+## Legacy v1 Treasury
+
+Don’t use the [v1 Treasury Financial Accounts API](https://docs.stripe.com/api/treasury/financial_accounts.md) (`POST /v1/treasury/financial_accounts`) for new integrations. Existing v1 integrations continue to work.

--- a/.claude/skills/stripe-projects/SKILL.md
+++ b/.claude/skills/stripe-projects/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: stripe-projects
+description: >-
+  Use when setting up a new app or local repo with Stripe Projects, provisioning
+  a software stack, or bootstrapping the Projects CLI from a coding agent.
+
+---
+
+Stripe Projects is a CLI for provisioning software stacks.
+
+Docs are here: https://docs.stripe.com/projects.md
+
+Download the Projects CLI and run `stripe projects init` to get started. You get access to more skills when you do that.
+
+To install the Stripe CLI and Projects plugin, Homebrew users can run `brew install stripe/stripe-cli/stripe && stripe plugin install projects`. For other installation options, see https://docs.stripe.com/stripe-cli/install.md.
+
+After `stripe projects init`, prefer the local project skills it creates.

--- a/.claude/skills/upgrade-stripe/SKILL.md
+++ b/.claude/skills/upgrade-stripe/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: upgrade-stripe
+description: Guide for upgrading Stripe API versions and SDKs
+
+---
+
+The latest Stripe API version is 2026-03-25.dahlia - use this version when upgrading unless the user specifies a different target version.
+
+# Upgrading Stripe Versions
+
+This guide covers upgrading Stripe API versions, server-side SDKs, Stripe.js, and mobile SDKs.
+
+## Understanding Stripe API Versioning
+
+Stripe uses date-based API versions (e.g., `2026-03-25.dahlia`, `2025-08-27.basil`, `2024-12-18.acacia`). Your account’s API version determines request/response behavior.
+
+### Types of Changes
+
+**Backward-Compatible Changes** (don’t require code updates):
+
+- New API resources
+- New optional request parameters
+- New properties in existing responses
+- Changes to opaque string lengths (e.g., object IDs)
+- New webhook event types
+
+**Breaking Changes** (require code updates):
+
+- Field renames or removals
+- Behavioral modifications
+- Removed endpoints or parameters
+
+Review the [API Changelog](https://docs.stripe.com/changelog.md) for all changes between versions.
+
+## Server-Side SDK Versioning
+
+See [SDK Version Management](https://docs.stripe.com/sdks/set-version.md) for details.
+
+### Dynamically-Typed Languages (Ruby, Python, PHP, Node.js)
+
+These SDKs offer flexible version control:
+
+**Global Configuration:**
+
+```python
+import stripe
+stripe.api_version = '2026-03-25.dahlia'
+```
+
+```ruby
+Stripe.api_version = '2026-03-25.dahlia'
+```
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-03-25.dahlia'
+});
+```
+
+**Per-Request Override:**
+
+```python
+stripe.Customer.create(
+  email="customer@example.com",
+  stripe_version='2026-03-25.dahlia'
+)
+```
+
+### Strongly-Typed Languages (Java, Go, .NET)
+
+These use a fixed API version matching the SDK release date. Don’t set a different API version for strongly-typed languages because response objects might not match the strong types in the SDK. Instead, update the SDK to target a new API version.
+
+### Best Practice
+
+Always specify the API version you’re integrating against in your code instead of relying on your account’s default API version:
+
+```javascript
+// Good: Explicit version
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-03-25.dahlia'
+});
+
+// Avoid: Relying on account default
+const stripe = require('stripe')('sk_test_xxx');
+```
+
+## Stripe.js Versioning
+
+See [Stripe.js Versioning](https://docs.stripe.com/sdks/stripejs-versioning.md) for details.
+
+Stripe.js uses an evergreen model with major releases (Acacia, Basil, Clover, Dahlia) on a biannual basis.
+
+### Loading Versioned Stripe.js
+
+**Via Script Tag:**
+
+```html
+<script src="https://js.stripe.com/dahlia/stripe.js"></script>
+```
+
+**Via npm:**
+
+```bash
+npm install @stripe/stripe-js
+```
+
+Major npm versions correspond to specific Stripe.js versions.
+
+### API Version Pairing
+
+Each Stripe.js version automatically pairs with its corresponding API version. For instance:
+
+- Dahlia Stripe.js uses `2026-03-25.dahlia` API
+- Acacia Stripe.js uses `2024-12-18.acacia` API
+
+You can’t override this association.
+
+### Migrating from v3
+
+1. Identify your current API version in code
+1. Review the changelog for relevant changes
+1. Consider gradually updating your API version before switching Stripe.js versions
+1. Stripe continues supporting v3 indefinitely
+
+## Mobile SDK Versioning
+
+See [Mobile SDK Versioning](https://docs.stripe.com/sdks/mobile-sdk-versioning.md) for details.
+
+### iOS and Android SDKs
+
+Both platforms follow **semantic versioning** (MAJOR.MINOR.PATCH):
+
+- **MAJOR**: Breaking API changes
+- **MINOR**: New functionality (backward-compatible)
+- **PATCH**: Bug fixes (backward-compatible)
+
+New features and fixes release only on the latest major version. Upgrade regularly to access improvements.
+
+### React Native SDK
+
+Uses a different model (0.x.y schema):
+
+- **Minor version changes** (x): Breaking changes AND new features
+- **Patch updates** (y): Critical bug fixes only
+
+### Backend Compatibility
+
+All mobile SDKs work with any Stripe API version you use on your backend unless documentation specifies otherwise.
+
+## Upgrade Checklist
+
+1. Review the [API Changelog](https://docs.stripe.com/changelog.md) for changes between your current and target versions
+1. Check [Upgrades Guide](https://docs.stripe.com/upgrades.md) for migration guidance
+1. Update server-side SDK package version (e.g., `npm update stripe`, `pip install --upgrade stripe`)
+1. Update the `apiVersion` parameter in your Stripe client initialization
+1. Test your integration against the new API version using the `Stripe-Version` header
+1. Update webhook handlers to handle new event structures
+1. Update Stripe.js script tag or npm package version if needed
+1. Update mobile SDK versions in your package manager if needed
+1. Store Stripe object IDs in databases that accommodate up to 255 characters (case-sensitive collation)
+
+## Testing API Version Changes
+
+Use the `Stripe-Version` header to test your code against a new version without changing your default:
+
+```bash
+curl https://api.stripe.com/v1/customers \
+  -u sk_test_xxx: \
+  -H "Stripe-Version: 2026-03-25.dahlia"
+```
+
+Or in code:
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-03-25.dahlia'  // Test with new version
+});
+```
+
+## Important Notes
+
+- Your webhook listener should handle unfamiliar event types gracefully
+- Test webhooks with the new version structure before upgrading
+- Breaking changes are tagged by affected product areas (Payments, Billing, Connect, etc.)
+- Multiple API versions coexist simultaneously, enabling staged adoption

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Template
 
-**34 skills. 8 commands. 6 agents. 3 MCPs. One setup script.**
+**37 skills. 8 commands. 6 agents. 3 MCPs. One setup script.**
 
-Claude Code のベストプラクティスを凝縮したテンプレート。`setup.sh` を実行するだけで、テスト駆動開発からマーケティング監査まで、34 のスキルがプロジェクトに即座に適用される。
+Claude Code のベストプラクティスを凝縮したテンプレート。`setup.sh` を実行するだけで、テスト駆動開発からマーケティング監査まで、37 のスキルがプロジェクトに即座に適用される。
 
 > **[Pro版 ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro)** — AIマルチエージェントチーム運用テンプレート。Conductor設定・Tier制PRレビュー・巡回レポート・コスト管理の実運用ノウハウを収録。[Free vs Pro 比較 →](#free-vs-pro)
 
@@ -76,7 +76,7 @@ chmod +x setup-claude.sh && ./setup-claude.sh
 | `/codex` | OpenAI Codex CLI 委譲 | Codex CLIにタスクを渡す時 |
 | `/ios` | iOS ビルド & 提出 | App Store提出ワークフロー |
 
-### Skills（34 スキル）
+### Skills（37 スキル）
 
 #### Development（11）
 
@@ -123,6 +123,14 @@ chmod +x setup-claude.sh && ./setup-claude.sh
 | `web-design-guidelines` | Web Interface Guidelines 準拠レビュー |
 | `app-onboarding` | アプリオンボーディング設計・改善 |
 | `paywall-upgrade-cro` | ペイウォール・アップグレード最適化 |
+
+#### Payments & Billing（3）
+
+| スキル | 用途 |
+|-------|------|
+| `stripe-best-practices` | Stripe 統合ガイド（API選択・Connect・課金・Treasury） |
+| `stripe-projects` | Stripe Projects CLI でのスタック構築 |
+| `upgrade-stripe` | Stripe API バージョン・SDK アップグレード |
 
 #### Content & Monetization（3）
 
@@ -262,7 +270,7 @@ EOF
 
 | | Free（このリポジトリ） | [Pro ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro) |
 |---|---|---|
-| **Skills** | 34 スキル | 34 スキル |
+| **Skills** | 37 スキル | 37 スキル |
 | **Commands** | 8 コマンド | 8 コマンド |
 | **Agents** | 6 エージェント | 6 エージェント |
 | **Hooks** | 6 フック | 6 フック |


### PR DESCRIPTION
## Summary
- publicリポ(mued-claude-code-template)で先行追加されていたStripe系スキル3つをprivateリポに逆同期
- READMEのスキル数を34→37に更新、Payments & Billingカテゴリを新設

## Changes
- `.claude/skills/stripe-best-practices/` — Stripe統合ガイド（API選択・Connect・課金・Treasury）
- `.claude/skills/stripe-projects/` — Stripe Projects CLIでのスタック構築
- `.claude/skills/upgrade-stripe/` — Stripe APIバージョン・SDKアップグレード
- `README.md` — スキル数更新、新カテゴリ追加

## Context
private↔public差分同期の一環。publicリポで先に追加されていた3スキルを取り込むことで、privateリポのスキルセットをsuperset化。

## Test plan
- [ ] 3スキルのSKILL.mdが正しく読み込まれることを確認
- [ ] READMEのスキル数表記が全箇所37で統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Stripe integration best-practices guides covering billing, Connect, payments, and treasury solutions
  * Added guidance for Stripe project setup and initialization
  * Added Stripe API version upgrade documentation with version management best practices

* **Chores**
  * Updated template documentation to reflect three new Stripe-related resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->