### PR TITLE
fix: setup.shにStripe系3スキル追加（37完全対応）

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -111,6 +111,10 @@ SHARED_SKILLS=(
   ai-interview-article
   note-serial-monetization
   freee-api-skill
+  # Payments & Billing
+  stripe-best-practices
+  stripe-projects
+  upgrade-stripe
 )
 for skill in "${SHARED_SKILLS[@]}"; do
   src="$TEMPLATE/skills/$skill"


### PR DESCRIPTION
## Summary
- PR#20のSHARED_SKILLS拡張時に含まれなかったStripe系3スキルを追加
- これでsetup.shが全37スキルに完全対応

## Changes
- `setup.sh`: Payments & Billingカテゴリとしてstripe-best-practices, stripe-projects, upgrade-stripeを追加

## Test plan
- [ ] setup.sh実行時に37スキル全てがリンクされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended platform setup to include three new Stripe-related capabilities: best practices, project templates, and upgrade guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->