### PR TITLE
docs: README/setup.shを38スキルに更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Template
 
-**37 skills. 8 commands. 6 agents. 3 MCPs. One setup script.**
+**38 skills. 8 commands. 6 agents. 3 MCPs. One setup script.**
 
-Claude Code のベストプラクティスを凝縮したテンプレート。`setup.sh` を実行するだけで、テスト駆動開発からマーケティング監査まで、37 のスキルがプロジェクトに即座に適用される。
+Claude Code のベストプラクティスを凝縮したテンプレート。`setup.sh` を実行するだけで、テスト駆動開発からマーケティング監査まで、38 のスキルがプロジェクトに即座に適用される。
 
 > **[Pro版 ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro)** — AIマルチエージェントチーム運用テンプレート。Conductor設定・Tier制PRレビュー・巡回レポート・コスト管理の実運用ノウハウを収録。[Free vs Pro 比較 →](#free-vs-pro)
 
@@ -76,7 +76,7 @@ chmod +x setup-claude.sh && ./setup-claude.sh
 | `/codex` | OpenAI Codex CLI 委譲 | Codex CLIにタスクを渡す時 |
 | `/ios` | iOS ビルド & 提出 | App Store提出ワークフロー |
 
-### Skills（37 スキル）
+### Skills（38 スキル）
 
 #### Development（11）
 
@@ -132,14 +132,14 @@ chmod +x setup-claude.sh && ./setup-claude.sh
 | `stripe-projects` | Stripe Projects CLI でのスタック構築 |
 | `upgrade-stripe` | Stripe API バージョン・SDK アップグレード |
 
-#### Content & Monetization（3）
+#### Content & Monetization（4）
 
 | スキル | 用途 |
 |-------|------|
 | `ai-interview-article` | インタビュー形式 note 記事作成 |
 | `note-serial-monetization` | note 連載の有料/無料設計 |
 | `freee-api-skill` | freee API 操作ガイド |
-
+| `note-publish-flow` | note 記事公開フロー（公開前チェック・重複照合・通知） |
 ### Agents（6 サブエージェント）
 
 | エージェント | 用途 |
@@ -270,7 +270,7 @@ EOF
 
 | | Free（このリポジトリ） | [Pro ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro) |
 |---|---|---|
-| **Skills** | 37 スキル | 37 スキル |
+| **Skills** | 38 スキル | 38 スキル |
 | **Commands** | 8 コマンド | 8 コマンド |
 | **Agents** | 6 エージェント | 6 エージェント |
 | **Hooks** | 6 フック | 6 フック |

--- a/setup.sh
+++ b/setup.sh
@@ -111,7 +111,7 @@ SHARED_SKILLS=(
   ai-interview-article
   note-serial-monetization
   freee-api-skill
-  # Payments & Billing
+  note-publish-flow  # Payments & Billing
   stripe-best-practices
   stripe-projects
   upgrade-stripe


### PR DESCRIPTION
## Summary
- PR#23でnote-publish-flowスキルが追加されたため、README/setup.shのスキル数を37→38に更新

## Changes
- `README.md` — スキル数表記更新、Content & Monetizationカテゴリにnote-publish-flow追加
- `setup.sh` — SHARED_SKILLSにnote-publish-flow追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)