### PR TITLE
[self-review] docs: README GumroadリンクにUTM付与

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Claude Code のベストプラクティスを凝縮したテンプレート。`setup.sh` を実行するだけで、テスト駆動開発からマーケティング監査まで、38 のスキルがプロジェクトに即座に適用される。
 
-> **[Pro版 ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro)** — AIマルチエージェントチーム運用テンプレート。Conductor設定・Tier制PRレビュー・巡回レポート・コスト管理の実運用ノウハウを収録。[Free vs Pro 比較 →](#free-vs-pro)
+> **[Pro版 ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro?utm_source=github&utm_medium=readme&utm_campaign=claude-code-template)** — AIマルチエージェントチーム運用テンプレート。Conductor設定・Tier制PRレビュー・巡回レポート・コスト管理の実運用ノウハウを収録。[Free vs Pro 比較 →](#free-vs-pro)
 
 ---
 
@@ -268,7 +268,7 @@ EOF
 
 ## Free vs Pro
 
-| | Free（このリポジトリ） | [Pro ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro) |
+| | Free（このリポジトリ） | [Pro ($29)](https://glasswerks.gumroad.com/l/claude-code-template-pro?utm_source=github&utm_medium=readme&utm_campaign=claude-code-template) |
 |---|---|---|
 | **Skills** | 38 スキル | 38 スキル |
 | **Commands** | 8 コマンド | 8 コマンド |
@@ -287,7 +287,7 @@ EOF
 
 Claude Code を 1 人で使うなら Free で十分。複数エージェントをチームとして運用するなら、Pro の運用テンプレートで立ち上げ時間を大幅に短縮できる。
 
-**[$29 — Gumroad で購入](https://glasswerks.gumroad.com/l/claude-code-template-pro)**
+**[$29 — Gumroad で購入](https://glasswerks.gumroad.com/l/claude-code-template-pro?utm_source=github&utm_medium=readme&utm_campaign=claude-code-template)**
 
 ---
 


### PR DESCRIPTION
## Summary
- README.md内のGumroad Pro Templateリンク3箇所に UTMパラメータを追加
- パターン: \`?utm_source=github&utm_medium=readme&utm_campaign=claude-code-template\`
- conductor依頼（data課命名規則準拠、mued課PR#133経由で全課統一）

## Tier判定
**Tier 1**: docs変更のみ（セルフマージ対象）
- 価格・認証・DB・本番設定・新規サービス導入いずれも該当せず
- コード変更なし（README.mdのリンクのみ）

## 変更箇所
- L7: ヘッダーの Pro版バッジリンク
- L271: Free vs Pro 比較テーブルヘッダー
- L290: CTA「\$29 — Gumroad で購入」

## スコープ外（今回は見送り）
- \`CLAUDE.md.template:124\` と \`setup.sh:225\` にもGumroadリンクあり
- これらは medium=readme ではないため、必要なら別途 medium=template / medium=setup で追加指示ください

## Test plan
- [x] リンクが正しくrender される（Markdownプレビュー確認済）
- [x] UTMパラメータが全3箇所統一
- [x] 4/17中間判定でGA4の流入元別CVRに反映される見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gumroad purchase links in README with tracking parameters to better monitor traffic sources from GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->