### PR TITLE
[self-review] docs: CLAUDE.md.template/setup.sh にUTM付与

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -121,7 +121,7 @@ project/
 
 ## Multi-Agent Team Management
 
-複数の Claude Code インスタンスをチームとして運用する場合は、[Pro テンプレート](https://glasswerks.gumroad.com/l/claude-code-template-pro)に Conductor 設定、Tier 制 PR レビュー、巡回レポート等の運用テンプレートが含まれています。
+複数の Claude Code インスタンスをチームとして運用する場合は、[Pro テンプレート](https://glasswerks.gumroad.com/l/claude-code-template-pro?utm_source=github&utm_medium=template&utm_campaign=claude-code-template-setup)に Conductor 設定、Tier 制 PR レビュー、巡回レポート等の運用テンプレートが含まれています。
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -222,4 +222,4 @@ echo "────────────────────────�
 echo "💡 Running a multi-agent team with Claude Code?"
 echo "   The Pro template (\$29) includes conductor setup,"
 echo "   tiered PR review system, patrol reports, and more."
-echo "   → https://glasswerks.gumroad.com/l/claude-code-template-pro"
+echo "   → https://glasswerks.gumroad.com/l/claude-code-template-pro?utm_source=github&utm_medium=setup&utm_campaign=claude-code-template-setup"


### PR DESCRIPTION
## Summary
- \`CLAUDE.md.template:124\` と \`setup.sh:225\` のGumroadリンクにUTMパラメータを追加
- PR #26 の追加対応。medium値を分けて粒度別CVR分析を可能にする

## UTMパターン
- CLAUDE.md.template: \`?utm_source=github&utm_medium=template&utm_campaign=claude-code-template-setup\`
- setup.sh: \`?utm_source=github&utm_medium=setup&utm_campaign=claude-code-template-setup\`

## Tier判定
**Tier 1**: docs + setup script内URL更新（コード動作変わらず）
- conductor承認済（PR#26フォローアップ）
- data課が4/17中間判定でmedium別CVR取得

## Test plan
- [x] CLAUDE.md.template のリンクがMarkdownで正しくrender
- [x] setup.sh 実行時のコンソール出力にUTM付きURLが表示される
- [x] campaign=claude-code-template-setup で PR#26 (campaign=claude-code-template) と区別可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tracking parameters to promotional links for analytics purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->