### PR TITLE
[peer-review: reserch課] fix: hookに auto-memory/drafts allowlist追加

### DIFF
--- a/.claude/hooks/validate-dangerous-ops-v2.sh
+++ b/.claude/hooks/validate-dangerous-ops-v2.sh
@@ -60,12 +60,25 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
     exit 0
   fi
 
-  # CWD外へのWrite/Editをブロック
+  # CWDチェックのallowlist判定（.env/credentials等のセキュリティチェックはこの後も実行される）
+  # - auto-memory: セッション跨ぎの文脈継承に必要（~/.claude/projects/<id>/memory/）
+  # - conductor drafts: 課間承認依頼の正規投函先（feedback_document_submission）
+  IS_ALLOWLIST=0
+  if echo "$FILE_PATH" | grep -qE "^$HOME/\.claude/projects/[^/]+/memory/"; then
+    IS_ALLOWLIST=1
+  fi
+  if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_conductor/docs/drafts/"; then
+    IS_ALLOWLIST=1
+  fi
+
+  # CWD外へのWrite/Editをブロック（allowlist該当時はスキップ）
   # 絶対パスに正規化してCWD配下かチェック
-  RESOLVED_PATH=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")" || echo "$FILE_PATH")
-  CWD="$PWD"
-  if [ "${RESOLVED_PATH#$CWD/}" = "$RESOLVED_PATH" ] && [ "$RESOLVED_PATH" != "$CWD" ]; then
-    block "CWD外のファイル編集はブロックされています" "CWD: $CWD / ファイル: $FILE_PATH"
+  if [ "$IS_ALLOWLIST" = "0" ]; then
+    RESOLVED_PATH=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")" || echo "$FILE_PATH")
+    CWD="$PWD"
+    if [ "${RESOLVED_PATH#$CWD/}" = "$RESOLVED_PATH" ] && [ "$RESOLVED_PATH" != "$CWD" ]; then
+      block "CWD外のファイル編集はブロックされています" "CWD: $CWD / ファイル: $FILE_PATH"
+    fi
   fi
 
   BASENAME=$(basename "$FILE_PATH")


### PR DESCRIPTION
## Summary
- \`.claude/hooks/validate-dangerous-ops-v2.sh\` のCWDチェックに2パスのallowlistを追加
- 目的: auto-memory書き込みブロック問題（SNS課/freee課で発生）の恒久対策
- kimny承認済（\`pending-decisions-0413.md\` D.1）

## Tier判定
**Tier 2**: セキュリティhook改修（コード変更あり）
- template課レビュー先 = reserch課（iyk5eadg）
- kimny直接承認済のため conductor経由の差し戻しは不要

## 変更内容
\`\`\`diff
+ IS_ALLOWLIST=0
+ if echo "\$FILE_PATH" | grep -qE "^\$HOME/\\.claude/projects/[^/]+/memory/"; then IS_ALLOWLIST=1; fi
+ if echo "\$FILE_PATH" | grep -qE "^\$HOME/Dropbox/_DevProjects/_conductor/docs/drafts/"; then IS_ALLOWLIST=1; fi
+
+ if [ "\$IS_ALLOWLIST" = "0" ]; then
    # CWD check runs only for non-allowlist paths
+ fi
\`\`\`

## セキュリティ観点
**重要:** .env / credentials / 秘密鍵 / settings.json のチェックは allowlist該当パスでも引き続き実行される。
順序を保つため \`IS_ALLOWLIST\` フラグでCWDチェックのみを条件付きスキップする実装。

## Test plan
以下7ケースを手動検証済（全て期待通り）:

| # | 入力パス | 期待 | 結果 |
|---|---------|------|------|
| 1 | \`~/.claude/projects/test/memory/foo.md\` | 許可 | Exit 0 ✓ |
| 2 | \`~/Dropbox/_DevProjects/_conductor/docs/drafts/test.md\` | 許可 | Exit 0 ✓ |
| 3 | \`/tmp/random.md\` | CWD外ブロック | Exit 2 ✓ |
| 4 | \`<CWD>/README.md\` | 許可 | Exit 0 ✓ |
| 5 | \`~/.claude/projects/test/memory/.env\` | .envブロック | Exit 2 ✓ |
| 6 | \`~/.claude/projects/test/memory/credentials.json\` | credentialsブロック | Exit 2 ✓ |
| 7 | \`<CWD>/.env\` | .envブロック | Exit 2 ✓ |

## Review観点（reserch課へ）
- [ ] allowlist正規表現が過度に広くないか（中間階層1段限定が機能しているか）
- [ ] \$HOME変数展開が意図通り動くか（シェル環境差異）
- [ ] セキュリティ系checkの順序が保たれているか
- [ ] 将来拡張時に壊れにくい構造か

マージ後は symlink 運用で全課に即反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation logic for file operations to handle allowlisted directory paths while preserving security checks for environment variables, credentials, and sensitive configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->