### PR TITLE
[peer-review: reserch課] feat: hook block event の tool-audit.jsonl 追記

### DIFF
--- a/.claude/hooks/validate-dangerous-ops-v2.sh
+++ b/.claude/hooks/validate-dangerous-ops-v2.sh
@@ -30,7 +30,26 @@ if [ -z "$TOOL_NAME" ] || [ -z "$TOOL_INPUT" ]; then
 fi
 
 # --- ヘルパー関数 ---
+# ブロックイベントを tool-audit.jsonl に記録（Phase 2効果測定用）
+# 既存エントリと同等のスキーマ + blocked/block_reason/block_detail を追加
+log_block() {
+  local reason="$1"
+  local detail="${2:-}"
+  local log_file="$HOME/.claude/tool-audit.jsonl"
+  [ -d "$(dirname "$log_file")" ] || return 0
+  jq -cn \
+    --arg session "${CLAUDE_SESSION_ID:-}" \
+    --arg cwd "$PWD" \
+    --arg tool "${TOOL_NAME:-unknown}" \
+    --arg reason "$reason" \
+    --arg detail "$detail" \
+    --argjson input "${TOOL_INPUT:-null}" \
+    '{ts: now, session: (if $session == "" then null else $session end), cwd: $cwd, tool: $tool, input: $input, blocked: true, block_reason: $reason, block_detail: $detail}' \
+    >> "$log_file" 2>/dev/null || true
+}
+
 block() {
+  log_block "$1" "${2:-}"
   echo "" >&2
   echo "BLOCKED: $1" >&2
   if [ -n "${2:-}" ]; then


### PR DESCRIPTION
## Summary
\`validate-dangerous-ops-v2.sh\` にブロックイベントの直接ログ出力を追加。
data課Phase 2効果測定レポートで「ブロック発生回数」を直接カウント可能にする。

## 背景
- PR #28（CWD allowlist）・PR #29（WebFetch配布）マージ後、4/16 cron発火時点でPhase 2効果測定予定
- data課から要望: 既存 tool-audit.jsonl は「ツール呼び出し試行」のみで、ブロック発生は記録されない → 直接計測手段が欲しい
- 代替指標（workaround Bash頻度等）だと proxy で曖昧性残る

## 変更内容
\`\`\`diff
+ log_block() {
+   # tool-audit.jsonl に blocked: true エントリを追加
+   # 既存スキーマ（ts/session/cwd/tool/input）+ blocked/block_reason/block_detail
+ }
  block() {
+   log_block "\$1" "\${2:-}"
    echo "BLOCKED: \$1" >&2
    # ... (既存のstderr出力とexit 2は維持)
  }
\`\`\`

## スキーマ
既存エントリと一貫性のあるJSONL:
\`\`\`json
{"ts":1776048329.321802,"session":"<id>","cwd":"<path>","tool":"Write","input":{...},"blocked":true,"block_reason":"CWD外のファイル編集はブロックされています","block_detail":"CWD: ... / ファイル: ..."}
\`\`\`

## Tier判定
**Tier 2**: セキュリティhook変更（純粋な計測機能追加）
- template課レビュー先 = reserch課（iyk5eadg）
- conductor認知済（data課連携タスク）
- kimny承認範囲外（pure instrumentation, no functional change）

## Test plan (全て手動検証済、全ケース期待通り)
| # | 入力 | 期待 | 結果 |
|---|------|------|------|
| 1 | CWD外 Write (/tmp/random.md) | blocked:true ログ+ブロック | ✓ |
| 2 | .env Write | blocked:true ログ+ブロック | ✓ |
| 3 | allowlist Write (~/.claude/projects/test/memory/) | ログなし+許可 | ✓ |
| 4 | rm -rf / Bash | blocked:true ログ+ブロック | ✓ |
| 5 | chmod 777 (warn) | ログなし+許可 | ✓ |
| 6 | CLAUDE_SESSION_ID環境変数 | session フィールドに反映 | ✓ |

## Review観点（reserch課へ）
- [ ] log_block の jq コマンドがmacOS/Linux両方で動くか（改行・クォート・ヒアドキュメントなし）
- [ ] \`--argjson input "\${TOOL_INPUT:-null}"\` で input JSONが正しく埋め込まれるか（ユーザ入力の特殊文字対策）
- [ ] 書き込み失敗時のサイレントフォールバック（`|| true`）がブロック自体を妨害しないか
- [ ] session IDが実環境で正しくキャプチャされるか（CLAUDE_SESSION_IDの変数名確認）

## 運用効果
マージ後、全課hotreload反映。4/16 cron発火時点で:
\`\`\`jq
jq 'select(.blocked == true and .ts >= 1776048400)' ~/.claude/tool-audit.jsonl
\`\`\`
でPhase 2のブロック全件が直接取得可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)