### PR TITLE
[self-review] docs: CLAUDE.mdにpricing一次ソース(freee課)参照を明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ claude-code-template/
 - **価格は$29固定。** 値下げ・PWYW提案はPolicy Gateを通すこと
 - 日英バイリンガル必須（全ファイルにen/ディレクトリ）
 
+### 価格・原価情報の一次ソース
+
+**料金・原価の一次ナレッジはfreee課が管理**（2026-04-13 kimny確立）。
+
+- 一次ソース: `freee-MCP/docs/knowledge/pricing-facts/gumroad-pricing.md`
+- template課CLAUDE.md/public README/setup.shの `$29` 表記は静的キャッシュとして維持（外部公開の表記安定性のため）
+- 価格変更・コスト見直し・損益分析等の判断材料は freee課ナレッジを参照
+- public資産（README.md, setup.sh）の $29 は変更前にfreee課ナレッジと整合確認
+
 ## 配布ルール
 
 - 全課配布スクリプト実行前に必ず `--dry-run` で確認


### PR DESCRIPTION
## Summary
2026-04-13 kimny確立の「freee課=全社料金・原価の一次ナレッジハブ」方針反映。

CLAUDE.md の Gumroad Pro版管理ルールセクションに「価格・原価情報の一次ソース」小節を追加:
- 一次ソース = \`freee-MCP/docs/knowledge/pricing-facts/gumroad-pricing.md\`
- public資産（README.md/setup.sh）の \$29 表記は静的キャッシュとして維持
- 価格変更判断時は freee課ナレッジと整合確認

## Tier判定
**Tier 1**: CLAUDE.md内部ドキュメントのみ変更、コード変更なし、public表記変更なし
- conductor C案採用承認済（public README/setup.sh は \$29 固定維持、CLAUDE.md/内部docsのみ freee課参照明文化）

## 変更箇所
\`CLAUDE.md:86-100\` のGumroad Pro版管理ルールセクション

## Test plan
- [x] CLAUDE.md の構造が崩れていないか（Markdown preview確認済）
- [x] public README.md / setup.sh は変更なし
- [x] 既存ルール（価格\$29固定、Policy Gate）と整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidelines to establish a primary knowledge source for pricing and cost information, with requirements for verification and consistency across public-facing materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->