### PR TITLE
feat: opusplan運用ルール追記（全peer共通ルール + /plan発動条件 + availableModels非追加）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,87 @@ chrome拡張（claude-in-chrome）は共有リソース。同時に1課しか使
 
 戦略的提案はconductor経由でpolicy-gate（経営部会議）を通してからCEO(kimny)に提示する。
 
+## opusplan 運用と plan mode の出入りルール（2026-04-14〜）
+
+本peerは 起動時に `--model` フラグで動作モードが指定されている（`_conductor/scripts/start-all-peers-ghostty.sh` 参照）。template課は `opusplan` モードで起動される。
+
+### plan mode の出入りは「タスク単位」で行う
+
+1つのタスク内で plan mode を複数回出入りしない。**1タスク = 0回または1回の plan 発動**を原則とする。
+
+#### 背景
+
+plan mode の出入りに伴う Opus/Sonnet 自動切替は、内部的に「会話履歴の再処理コスト」が乗る（template課調査結果）。長セッションで plan mode を頻繁に出入りする peer は、想定より消費が膨らむ可能性がある。本案の Opus 消費見込み（現状100 → v2適用後20-35）は、plan modeが必要なタスクで1回ずつ発動する前提で計算している。
+
+#### 具体運用
+
+- 「設計しながら少し実装、また設計に戻る」という細切れの切り替えは禁止
+- 設計が必要なら最初に `/plan` を発動し、設計が完了したら plan mode を解除して実装に移る
+- 実装中に追加の設計判断が必要になったら、その時点でのタスクを一旦完了し、**新しいタスク**として次の `/plan` を発動する
+- 同一タスク内で複数回の切替が必要になるケースは、タスク粒度が大きすぎる兆候。タスクを分割する
+
+#### 判定フロー
+
+タスク開始時に以下の順で判定する:
+
+1. このタスクは発動条件（本peerの `/plan 発動条件` セクション）に該当するか
+2. 該当する場合: 最初に `/plan` を発動して設計を完了させる → plan mode解除 → 実装
+3. 該当しない場合: Sonnet のまま実装
+4. 実装中に設計判断が必要になったら → 今のタスクをまず完了し、次のタスクで改めて `/plan` 発動
+
+#### 禁止パターン
+
+- plan mode → 実装（部分的）→ plan mode → 実装（部分的）→ plan mode ... のような繰り返し切替
+- 「設計が足りないかも」と感じた時点で plan mode に戻る（戻らず次タスクに分ける）
+- 一つの長大タスクを plan mode のまま完走する（plan mode は設計段階のみ、実装で Sonnet に戻す）
+
+#### タスク分割の目安
+
+- 1タスク = 1コミットに収まる粒度を目安にする
+- plan mode で決めた設計が 3ファイル以上の変更を伴う場合は、ファイル単位で実装タスクを分割してもよい
+- その場合、分割後のタスクは通常 Sonnet で実装するだけで済む（設計は最初の `/plan` で終わっているため）
+
+## /plan 発動条件
+
+このpeerは opusplan モードで動作する。/plan を発動した時のみ Opus が呼ばれ、
+それ以外は Sonnet で動作する。以下の条件に該当する場合に /plan を発動する。
+
+### 発動すべきケース
+- 新規skillの設計（SKILL.md を 0 から書き起こす、挙動仕様とトリガー条件を決める）
+- 新規hookの設計（PreToolUse/Stop/SessionStart等の挙動仕様を決める）
+- **既存skill/hookの仕様変更を伴う書き換え**（挙動が変わる、トリガー条件が変わる、入出力フォーマットが変わる、対象ファイルが変わる等）
+- 全課配布する設定変更で、複数課の既存運用に影響する内容（settings.local.json / .mcp.json / validate-dangerous-ops-v2.sh 等）
+- Gumroad Pro版パッケージ方針の変更（同梱物の追加・削除・再編成）
+- reserch課から依頼された外部ベストプラクティスのスキル化判断（A+B+C評価の合議設計）
+- CCOとして全peerに影響するガードレール追加・運用ルール策定
+
+### 発動しないケース（Sonnetで処理する）
+- 既存skillの誤字修正・例示追加・脱字修正（仕様変更を伴わないもの）
+- 既存skillのコメント変更・文言調整（挙動・トリガー条件・入出力に影響しないもの）
+- `skills-lock.json` のバージョン更新
+- `setup.sh` の既定値差し替え（パラメータ変更のみ、ロジック変更なし）
+- `premium/` 配下のドキュメント軽微更新（README.md の追記、サンプルファイル追加）
+- 既存hookのログ出力文言調整・閾値の微調整（挙動ロジックは変えない場合）
+- `scripts/distribute-*.sh` の既存ロジック踏襲実行（--dry-run 含む）
+- 既存commandの文言調整（/commit /pr /ship /build-fix /learn /security /ios）
+
+### 判断に迷ったとき
+- 原則 Sonnet 側に倒す。skillやhookの「軽微修正」と「新規設計」の判定は**「新規ファイル作成 または既存ファイルの仕様変更を伴う書き換え」か「誤字・パラメータ調整・ログ文言変更・既定値差し替え」か**で分ける。前者は /plan 発動、後者は Sonnet。
+- **「仕様変更」の判定基準**: skill/hookの挙動が変わる、トリガー条件が変わる、入出力フォーマットが変わる、対象ファイル・対象コマンドが変わる等。文言・例示・コメント・ログ表現の変更のみは仕様変更に該当しない。
+- 量的閾値（部分書き換え何％など）は使わない。仕様変更を伴うか否かの質的判定で切る。
+
+## 運用ルール: `availableModels` は settings.json に追加しない
+
+2026-04-14 opusplan運用開始に伴い確立された全課共通ルール。
+
+### ルール
+`~/.claude/settings.json` / `~/.claude/settings.local.json` / 各peer の `.claude/settings.local.json` いずれにも `availableModels` 項目を追加しない。現状追加されていないことは template課が2026-04-14時点で確認済み。
+
+### 理由
+GitHub issue [anthropics/claude-code#41720](https://github.com/anthropics/claude-code/issues/41720) で、`availableModels` をカスタマイズした環境で `sonnet[1m]` / `opus[1m]` / `haiku` などを経由すると `/model opusplan` に戻れなくなるバグが報告されている。発動条件は `availableModels` のカスタム追加のみ。追加しなければこのバグ面を踏まない。
+
+### 運用
+- モデル切替は起動時の `--model` フラグ（`claudepeers --model opusplan` 等）または実行中の `/model default` → `/model opusplan` 2段切替で行う
+- 将来 `availableModels` が必要になるユースケースが出た場合は、本ルール改定を伴う承認フロー（policy-gate）を通すこと
+- Claude Code update（`claude update`）でバグ修正が取り込まれた後も、代替手段が十分機能しているため、`availableModels` の追加は原則継続して行わない
+


### PR DESCRIPTION
## Summary

2026-04-14 kimny承認済みのopusplan運用開始に伴い、template課 CLAUDE.md 末尾に以下3セクションを追記:

- **opusplan運用と plan mode の出入りルール**（全peer共通。タスク単位での /plan 発動、プランモード細切れ切替禁止）
- **/plan 発動条件**（template課個別。`_conductor/docs/inbox/peer_plan_triggers/template_plan_trigger.md` 準拠）
- **`availableModels` 非追加ルール**（全課共通。issue #41720 回避のため settings.json への追加禁止）

## 背景

- conductorから opusplan 運用の技術前提調査依頼を受領 → 調査回答（`_conductor/docs/drafts/template_opusplan_investigation_response.md`）で適用可能と報告
- kimny承認後、conductor経由で配布作業3点（A/B/C）が依頼され、本PRは作業B（template課分）+ 作業C（template課分）に相当
- 作業A（`_conductor/scripts/start-all-peers-ghostty.sh` への `--model` 追加）と作業B（他9課分）は別PRで進行

## Tier 判断

**Tier 3**（全peer方針変更、conductor承認必須）

## 関連ドキュメント

- 配布パッケージ全体: \`_conductor/docs/drafts/opusplan_rollout_plan.md\`
- 調査回答: \`_conductor/docs/drafts/template_opusplan_investigation_response.md\`
- peer別 /plan 発動条件: \`_conductor/docs/inbox/peer_plan_triggers/\`

## Test plan

- [x] CLAUDE.md 末尾に3セクションが追加されていること（+84行）
- [x] 共通ルール・発動条件・availableModels ルールの3セクションすべてに見出しあり
- [x] template_plan_trigger.md の内容と発動条件セクションが一致
- [ ] conductor レビュー・承認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidelines and procedures documentation for development workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->