### PR TITLE
feat: hook allowlist に _conductor/docs/inbox/ を追加

### DIFF
--- a/.claude/hooks/validate-dangerous-ops-v2.sh
+++ b/.claude/hooks/validate-dangerous-ops-v2.sh
@@ -82,11 +82,15 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
   # CWDチェックのallowlist判定（.env/credentials等のセキュリティチェックはこの後も実行される）
   # - auto-memory: セッション跨ぎの文脈継承に必要（~/.claude/projects/<id>/memory/）
   # - conductor drafts: 課間承認依頼の正規投函先（feedback_document_submission）
+  # - conductor inbox: 各課の成果物・回答提出先（conductor指示に基づく正当なデリバリー）
   IS_ALLOWLIST=0
   if echo "$FILE_PATH" | grep -qE "^$HOME/\.claude/projects/[^/]+/memory/"; then
     IS_ALLOWLIST=1
   fi
   if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_conductor/docs/drafts/"; then
+    IS_ALLOWLIST=1
+  fi
+  if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_conductor/docs/inbox/"; then
     IS_ALLOWLIST=1
   fi
 


### PR DESCRIPTION
## Summary

- Phase 2 効果測定（`permission-audit-phase2-20260416.md`）で特定した **allowlist カバレッジ不足**を修正
- `validate-dangerous-ops-v2.sh` の allowlist に `_conductor/docs/inbox/` を追加
- 従来は `drafts/` のみ許可していたが、実際の成果物投函先は `inbox/` であり、6件の正当なデリバリーがブロックされていた

## 変更内容

`validate-dangerous-ops-v2.sh` allowlist に1エントリ追加:
```
$HOME/Dropbox/_DevProjects/_conductor/docs/inbox/
```

全課が同一の絶対パスでこのhookを参照しているため、配布スクリプト不要・このファイル1本で全課に即時反映される。

## 影響

- **Before**: 各課が `_conductor/docs/inbox/` に書き込むと `CWD外のファイル編集はブロックされています` でブロック
- **After**: conductor 指示に基づく正当な成果物提出が通過する

## Tier

Tier 2 — reserch課ピアレビュー依頼済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guidelines for plan activation and model switching policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->