### PR TITLE
feat: hook allowlist に _contents-writing/drafts/ と _videos/ を追加

### DIFF
--- a/.claude/hooks/validate-dangerous-ops-v2.sh
+++ b/.claude/hooks/validate-dangerous-ops-v2.sh
@@ -83,6 +83,8 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
   # - auto-memory: セッション跨ぎの文脈継承に必要（~/.claude/projects/<id>/memory/）
   # - conductor drafts: 課間承認依頼の正規投函先（feedback_document_submission）
   # - conductor inbox: 各課の成果物・回答提出先（conductor指示に基づく正当なデリバリー）
+  # - contents-writing drafts: SNS課が記事公開ワークフローで書き込む（Phase 2監査 P2推奨）
+  # - videos: SNS課が動画制作ワークフローで書き込む（Phase 2監査 P2推奨）
   IS_ALLOWLIST=0
   if echo "$FILE_PATH" | grep -qE "^$HOME/\.claude/projects/[^/]+/memory/"; then
     IS_ALLOWLIST=1
@@ -91,6 +93,12 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
     IS_ALLOWLIST=1
   fi
   if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_conductor/docs/inbox/"; then
+    IS_ALLOWLIST=1
+  fi
+  if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_contents-writing/drafts/"; then
+    IS_ALLOWLIST=1
+  fi
+  if echo "$FILE_PATH" | grep -qE "^$HOME/Dropbox/_DevProjects/_videos/"; then
     IS_ALLOWLIST=1
   fi
 


### PR DESCRIPTION
## 概要

Phase 2 permission監査 P2推奨事項の実装。

SNS課（CWD: `threads-api`）が記事公開・動画制作ワークフローで下記パスへのクロス書き込みが必要だが、現状 hook にブロックされている（Phase 2.5計測: 2件）。

## 変更内容

`validate-dangerous-ops-v2.sh` allowlistに2エントリ追加:
- `$HOME/Dropbox/_DevProjects/_contents-writing/drafts/` — 記事公開ワークフロー
- `$HOME/Dropbox/_DevProjects/_videos/` — 動画制作ワークフロー

## Tier判定

**Tier 3**（conductor承認必須）
- `validate-dangerous-ops-v2.sh` は全課が絶対パスで参照 → 全課波及
- `feedback_tier_classification.md` 参照

## セキュリティ評価

- `_contents-writing/drafts/`: write課の管理下。SNS課→write課間の協業パス。プロジェクト公開フローの正当な書き込み先。
- `_videos/`: video課の管理下。SNS課→video課間の協業パス。既存業務フロー（muedial-promoなど）での必要性確認済み。
- どちらも allowlist 追加により「書き込み許可」するのみ。`.env` ・機密ファイルブロック・Bash検証は引き続き全パスで有効。

## 根拠

`_conductor/docs/inbox/permission-audit-phase2-20260416.md` §3.4, §4 P2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation system configuration to include two additional directory patterns in the allowlist, enabling safer file operations in those locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->