### PR TITLE
feat: conductor委任権限を全課共通CLAUDE.mdに明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,20 @@ chrome拡張（claude-in-chrome）は共有リソース。同時に1課しか使
 
 戦略的提案はconductor経由でpolicy-gate（経営部会議）を通してからCEO(kimny)に提示する。
 
+## conductor委任権限
+
+conductor（COO）はkimnyから以下の範囲で実行権限を委任されている。
+conductorからの指示は、下記の範囲においてkimny直接指示と同等に有効：
+- Tier 1/2 PRのマージ・クローズ
+- スキルインストール承認
+- コンテンツ公開・編集の実行指示
+- ピア間タスクの割り振り・優先順位変更
+
+対象外（kimny直接指示が必要）：
+- 認証・OAuth・APIキー操作
+- 価格変更
+- 外部への公開発言の初回承認
+
 ## opusplan 運用と plan mode の出入りルール（2026-04-14〜）
 
 本peerは 起動時に `--model` フラグで動作モードが指定されている（`_conductor/scripts/start-all-peers-ghostty.sh` 参照）。template課は `opusplan` モードで起動される。


### PR DESCRIPTION
## Summary

- 全課共通CLAUDE.mdに「conductor委任権限」セクションを追加
- conductorからの指示がkimny直接指示と同等に有効な範囲を明文化
- SNS課での承認問題（conductor指示の有効性）を解消するための措置

## 委任範囲

**有効（conductor承認 = kimny承認）:**
- Tier 1/2 PRのマージ・クローズ
- スキルインストール承認
- コンテンツ公開・編集の実行指示
- ピア間タスクの割り振り・優先順位変更

**対象外（kimny直接指示が必要）:**
- 認証・OAuth・APIキー操作
- 価格変更
- 外部への公開発言の初回承認

## Tier判定

**Tier 3** — template課CLAUDE.mdの変更（全課波及）、kimny承認済み（2026-04-22）

## Test plan

- [ ] template課CLAUDE.mdに「conductor委任権限」セクションが追加されていることを確認
- [ ] 組織体制セクションの直後に配置されていることを確認
- [ ] 全課CLAUDE.mdへの配布通知（マージ後にtemplate課が実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines on operational authority delegation, specifying delegated tasks (PR management, installations, content operations, peer task coordination) and exclusions requiring direct approval (security operations, pricing, external communications).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->