### PR TITLE
fix: validate-dangerous-ops-v2.sh symlink迂回対策（P4 realpath正規化）

### DIFF
--- a/.claude/hooks/validate-dangerous-ops-v2.sh
+++ b/.claude/hooks/validate-dangerous-ops-v2.sh
@@ -105,8 +105,8 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
   # CWD外へのWrite/Editをブロック（allowlist該当時はスキップ）
   # 絶対パスに正規化してCWD配下かチェック
   if [ "$IS_ALLOWLIST" = "0" ]; then
-    RESOLVED_PATH=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")" || echo "$FILE_PATH")
-    CWD="$PWD"
+    RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null || (cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")") || echo "$FILE_PATH")
+    CWD=$(realpath "$PWD" 2>/dev/null || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$PWD" 2>/dev/null || echo "$PWD")
     if [ "${RESOLVED_PATH#$CWD/}" = "$RESOLVED_PATH" ] && [ "$RESOLVED_PATH" != "$CWD" ]; then
       block "CWD外のファイル編集はブロックされています" "CWD: $CWD / ファイル: $FILE_PATH"
     fi


### PR DESCRIPTION
## Summary

- `validate-dangerous-ops-v2.sh` の CWD 判定を `cd + pwd` から `realpath` 正規化に変更（P4）
- symlink 経由で CWD チェックを迂回できる理論的な穴を修正
- `FILE_PATH` と `CWD` の両方を正規化（片方だけでは macOS の `/tmp → /private/tmp` で誤動作）

## 変更内容

**108行目 FILE_PATH の正規化:**
```bash
# Before
RESOLVED_PATH=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")" || echo "$FILE_PATH")
# After (案D: realpath → python3 → cd+pwd フォールバック)
RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null || (cd "$(dirname "$FILE_PATH")" 2>/dev/null && echo "$(pwd)/$(basename "$FILE_PATH")") || echo "$FILE_PATH")
```

**109行目 CWD の正規化（追加）:**
```bash
# Before
CWD="$PWD"
# After
CWD=$(realpath "$PWD" 2>/dev/null || python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$PWD" 2>/dev/null || echo "$PWD")
```

## テスト結果（macOS）

| ケース | 期待 | 結果 |
|--------|------|------|
| symlink経由CWD外（`/project/escape -> /etc`） | BLOCKED | ✅ |
| CWD内通常ファイル | ALLOWED | ✅ |
| CWD外絶対パス（`/etc/hosts`） | BLOCKED | ✅ |

## Tier判定

**Tier 3** — 全課波及hook変更、conductor承認済み（2026-04-22）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced path resolution validation with improved fallback mechanisms to ensure more reliable security checks across various system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->