### PR TITLE
feat: distribute-skills.sh 追加 (段階1: 共通必須3スキル配布自動化)

### DIFF
--- a/scripts/distribute-skills.sh
+++ b/scripts/distribute-skills.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# distribute-skills.sh
+# 全課共通必須スキル3件（peer-id-lookup / tier-judge / plan-mode-policy）を配布する
+# 課固有 skill は触らず、配布対象 skill のみ rsync で同期
+# 既存 distribute-quality-standards.sh / distribute-settings-allow.sh と同パターン
+#
+# Usage:
+#   ./scripts/distribute-skills.sh --dry-run   # 差分プレビュー（rsync -n）
+#   ./scripts/distribute-skills.sh              # 本番実行
+#
+# 仕様:
+#   - 配布対象 skill が template 課マスタに無い場合は SKIP
+#   - 配布先課に対象 skill ディレクトリが無い場合は新規作成
+#   - rsync --delete は対象 skill ディレクトリ内に限定（他 skill には影響なし）
+#   - skills-lock.json の更新は手動（段階1ではスコープ外）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_BASE="$REPO_ROOT/.claude/skills"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "=== DRY RUN MODE ==="
+  echo ""
+fi
+
+# 配布対象 skill（共通必須のみ、課固有は対象外）
+COMMON_SKILLS=(
+  "peer-id-lookup"
+  "tier-judge"
+  "plan-mode-policy"
+)
+
+# 配布対象課（template課自身は除外、全10課）
+# 課名|.claude/skills絶対パス
+TARGETS="
+conductor|/Users/kimny/Dropbox/_DevProjects/_conductor/.claude/skills
+write|/Users/kimny/Dropbox/_DevProjects/_contents-writing/.claude/skills
+cowork|/Users/kimny/Dropbox/_DevProjects/_cowork/.claude/skills
+data|/Users/kimny/Dropbox/_DevProjects/_data-analysis/.claude/skills
+LP|/Users/kimny/Dropbox/_DevProjects/_LandingPage/glasswerks-lp/.claude/skills
+reserch|/Users/kimny/Dropbox/_DevProjects/_Reserch/.claude/skills
+freee|/Users/kimny/Dropbox/_DevProjects/freee-MCP/.claude/skills
+mued|/Users/kimny/Dropbox/_DevProjects/mued/mued_v2/.claude/skills
+native|/Users/kimny/Dropbox/_DevProjects/mued/mued_v2/apps/.claude/skills
+SNS|/Users/kimny/Dropbox/_DevProjects/mued/threads-api/.claude/skills
+"
+
+UPDATED=0
+CREATED=0
+SKIPPED=0
+
+echo "=== 共通必須スキル配布 ==="
+echo "配布対象: ${COMMON_SKILLS[*]}"
+echo ""
+
+# 配布対象 skill のソース存在確認（事前チェック）
+for skill in "${COMMON_SKILLS[@]}"; do
+  if [[ ! -d "$SKILLS_BASE/$skill" ]]; then
+    echo "  [ERROR] template課マスタに $skill が存在しません: $SKILLS_BASE/$skill"
+    echo "  処理を中断します"
+    exit 1
+  fi
+done
+
+echo "$TARGETS" | while IFS='|' read -r division target_dir; do
+  # 空行スキップ
+  [[ -z "$division" ]] && continue
+
+  if [[ ! -d "$target_dir" ]]; then
+    echo "  [SKIP] ${division}課: skills ディレクトリなし ($target_dir)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  echo "→ ${division}課 ($target_dir)"
+
+  for skill in "${COMMON_SKILLS[@]}"; do
+    src="$SKILLS_BASE/$skill"
+    dst="$target_dir/$skill"
+
+    if [[ -d "$dst" ]]; then
+      action="UPDATE"
+    else
+      action="CREATE"
+    fi
+
+    if $DRY_RUN; then
+      # dry-run: rsync -n で差分のみ表示
+      # 配布先ディレクトリが無い場合は新規作成相当の差分として表示
+      if [[ ! -d "$dst" ]]; then
+        echo "  [${action} DRY] $skill （新規作成、$(find "$src" -type f | wc -l | tr -d ' ') ファイル予定）"
+      else
+        # rsync -avn の出力から実差分行を抽出（grep失敗時は0件として扱う）
+        diff_lines=$(rsync -avn --delete "$src/" "$dst/" 2>/dev/null | grep -E '^>f|^cd|^deleting' || true)
+        diff_count=$(printf '%s' "$diff_lines" | grep -c . || true)
+        echo "  [${action} DRY] $skill （差分件数: ${diff_count:-0}）"
+        if [[ -n "$diff_lines" ]]; then
+          printf '%s\n' "$diff_lines" | sed 's/^/    /'
+        fi
+      fi
+    else
+      mkdir -p "$dst"
+      rsync -av --delete "$src/" "$dst/" > /dev/null
+      echo "  [${action}] $skill"
+    fi
+  done
+  echo ""
+done
+
+echo "=========================================="
+if $DRY_RUN; then
+  echo "DRY RUN 完了"
+  echo ""
+  echo "実行する場合: $0  （--dry-run なし）"
+else
+  echo "配布完了"
+  echo ""
+  echo "次の手動アクション:"
+  echo "  1. skills-lock.json のバージョン記録更新（必要に応じて）"
+  echo "  2. 配布結果を conductor へ報告（claude-peers）"
+fi
+echo "=========================================="


### PR DESCRIPTION
## Summary
- 全課共通必須スキル3件 (peer-id-lookup / tier-judge / plan-mode-policy) を全10課に配布する自動化スクリプト追加
- 既存 distribute-quality-standards.sh / distribute-settings-allow.sh と同パターン (rsync + --dry-run)
- 配布対象 skill のみ rsync --delete、課固有 skill には影響なし

## Tier
**Tier 3** — template課からの全課波及

## kimny 承認・判断 articulate
- kimny判断 (4/26 12:18): 段階1着手OK
- CCO判断 articulate: `_conductor/docs/drafts/distribute-skills-script-judgment-20260426.md`

## --dry-run 結果 (2026-04-26)

```
→ conductor課 — 3スキル新規作成 (初期化漏れ補完)
→ write/cowork/data/LP/reserch/freee/mued/native/SNS課 (9課)
   - peer-id-lookup: 差分件数 0 (既存と同一)
   - tier-judge: 差分件数 0 (既存と同一)
   - plan-mode-policy: 新規作成 (PR#41 マージ済の新スキル、全課で初配布)
```

**異常値検知ルール (template課 CLAUDE.md `--dry-run で 3課以上意図しない差分検出 → /plan発動`)**:
- ❌ 該当しない (全差分は意図通り)
- plan-mode-policy は新スキル → 全課新規配布が正常
- conductor の 2件初期化漏れ → 補完が正常

## 段階1 配布対象 skill
| skill | 用途 | kimny承認状況 |
|---|---|---|
| peer-id-lookup | claude-peers ID解決 | 既に全課で運用中 |
| tier-judge | PR Tier判定 | 既に全課で運用中 |
| plan-mode-policy | /plan発動条件 | PR#41マージ済 (kimny承認確定) |

## 段階2 (kimny判断後検討、本PRスコープ外)
- 課別配布マトリックス
- skills-lock.json 自動更新
- 課固有カスタマイズ保持

## Test plan
- [x] `--dry-run` で全10課差分プレビュー完了 (上記結果参照)
- [x] 配布対象 skill のソース存在確認 (事前チェック実装済)
- [x] 既存 distribute-*.sh との設計パターン整合確認
- [ ] conductor 承認後、本番実行
- [ ] 本番実行後、配布結果サマリ + skills-lock.json 手動更新 を conductor に通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool for distributing skill directories across course paths, featuring validation checks, automatic update/create workflows, and a `--dry-run` mode to preview changes before syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->